### PR TITLE
Fixed command not found error in sync_users

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -123,10 +123,10 @@ while read line; do
     # Create a user account if it does not already exist
     cut -d: -f1 /etc/passwd | grep -qx $USER_NAME
     if [ $? -eq 1 ]; then
-      /usr/sbin/adduser $USER_NAME && \\
-      mkdir -m 700 /home/$USER_NAME/.ssh && \\
-      chown $USER_NAME:$USER_NAME /home/$USER_NAME/.ssh && \\
-      echo "$line" >> ~/keys_installed && \\
+      /usr/sbin/adduser $USER_NAME && \
+      mkdir -m 700 /home/$USER_NAME/.ssh && \
+      chown $USER_NAME:$USER_NAME /home/$USER_NAME/.ssh && \
+      echo "$line" >> ~/keys_installed && \
       echo "`date --date="today" "+%Y-%m-%d %H-%M-%S"`: Creating user account for $USER_NAME ($line)" >> $LOG_FILE
     fi
 


### PR DESCRIPTION
Fixed issue with wrong line breaks that causes errors below
```
/usr/bin/bastion/sync_users: line 22: \: command not found
/usr/bin/bastion/sync_users: line 23: \: command not found
/usr/bin/bastion/sync_users: line 24: \: command not found
/usr/bin/bastion/sync_users: line 25: \: command not found
download: s3://......
```