### PR TITLE
replacing single quotes with double quotes in s3api ls sed replace 

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -113,7 +113,7 @@ get_user_name () {
 }
 
 # For each public key available in the S3 bucket
-aws s3api list-objects --bucket ${bucket_name} --prefix public-keys/ --region ${aws_region} --output text --query 'Contents[?Size>`0`].Key' | sed -e 's/\\t/\\n/' > ~/keys_retrieved_from_s3
+aws s3api list-objects --bucket ${bucket_name} --prefix public-keys/ --region ${aws_region} --output text --query 'Contents[?Size>`0`].Key' | sed -e "s/\\t/\\n/" > ~/keys_retrieved_from_s3
 while read line; do
   USER_NAME="`get_user_name "$line"`"
 


### PR DESCRIPTION
With more than one .pub in the s3 bucket, the given sed line does not replace the tab with a newline using single quotes. Changing to double quotes fixed this problem for me.