### PR TITLE
Added CIDR for SSH egress, added security group as an output, fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module will create an SSH bastion to securely connect in SSH  to your priva
 ![Bastion Infrastrucutre](https://raw.githubusercontent.com/Guimove/terraform-aws-bastion/master/_docs/terraformawsbastion.png)
 All SSH  commands are logged on an S3 bucket for security compliance, in the /logs path.
 
-SSH  users are managed by their public key, simply drop the SSH key of the user in  the /public_keys path of the bucket.
+SSH  users are managed by their public key, simply drop the SSH key of the user in  the /public-keys path of the bucket.
 Keys should be named like 'username.pub', this will create the user 'username' on the bastion server.
 
 Then after you'll be able to connect to the server with : 

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ resource "aws_security_group" "bastion_host_security_group" {
     from_port = "${var.private_ssh_port}"
     protocol  = "TCP"
     to_port   = "${var.private_ssh_port}"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "bucket_name" {
 output "elb_ip" {
   value = "${aws_lb.bastion_lb.dns_name}"
 }
+
+output "private_instances_security_group" {
+  value = "${aws_security_group.private_instances_security_group.id}"
+}


### PR DESCRIPTION
I've made the following changes:
- added a CIDR for SSH egress so that the rule is properly added to the security group
- added the private_instances_security_group as an output so that it can be assigned to instances
- changed "public_keys" to "public-keys" in README (hyphen instead of underscore)