### PR TITLE
Escape double quotes

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -117,7 +117,7 @@ cat > /usr/bin/bastion/sync_users << 'EOF'
 
 # We check that the previous copy is not already running
 for pid in $(pgrep -f sync_users); do
-    if [ $pid != $$ ]; then
+    if [ $pid != $$$ ]; then
         echo "[$(date)] : sync_users : Process is already running with PID $pid"
         exit 1
     else


### PR DESCRIPTION
Without this I'm seeing that this becomes `if [ $pid != $]; then` in the user data and the sync never runes.