### PR TITLE
Replace sed with tr so it can create keys_retrieved_from_s3 file

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -135,7 +135,7 @@ get_user_name () {
 }
 
 # For each public key available in the S3 bucket
-aws s3api list-objects --bucket ${bucket_name} --prefix public-keys/ --region ${aws_region} --output text --query 'Contents[?Size>`0`].Key' | sed -e "s/\t/\n/" > ~/keys_retrieved_from_s3
+aws s3api list-objects --bucket ${bucket_name} --prefix public-keys/ --region ${aws_region} --output text --query 'Contents[?Size>`0`].Key' | tr '\t' '\n' > ~/keys_retrieved_from_s3
 while read line; do
   USER_NAME="`get_user_name "$line"`"
 


### PR DESCRIPTION
Fixed https://github.com/Guimove/terraform-aws-bastion/issues/21

We have found in some cases, when there are multiple ssh public keys in our s3 buckets, the file `keys_retrieved_from_s3 file` created seems to have the contents malformed, like this:

```
public-keys/user1.pub
public-keys/user2.pub	public-keys/user3.pub	public-keys/user4.pub
```

where in fact, it should look like this:
```
public-keys/user1.pub
public-keys/user2.pub
public-keys/user3.pub
public-keys/user4.pub
```

This PR hopefully fixes it.