### PR TITLE
Filter for x86_64 architecture

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -10,4 +10,9 @@ data "aws_ami" "amazon-linux-2" {
     name   = "name"
     values = ["amzn2-ami-hvm*"]
   }
+  
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
 }


### PR DESCRIPTION
Make sure we're getting AMI for the correct architecture.
Otherwise you can get AMI for `arm64`