### PR TITLE
Adds `extra_user_data_content` variable + Documents existing additional output variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ module "bastion" {
 | cidrs | List of CIDRs than can access to the bastion. Default : 0.0.0.0/0 | list | `<list>` | no |
 | create_dns_record | Choose if you want to create a record name for the bastion (LB). If true 'hosted_zone_name' and 'bastion_record_name' are mandatory | integer | - | yes |
 | elb_subnets | List of subnet were the ELB will be deployed | list | - | yes |
+| extra_user_data_content | Additional scripting to pass to the bastion host. For example, this can include installing postgresql for the `psql` command. | string | `""` | no |
 | hosted_zone_name | Name of the hosted zone were we'll register the bastion DNS name | string | `` | no |
 | is_lb_private | If TRUE the load balancer scheme will be "internal" else "internet-facing" | string | - | yes |
 | log_auto_clean | Enable or not the lifecycle | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ module "bastion" {
 | Name | Description |
 |------|-------------|
 | bucket_name |  |
-| elb_ip |  |
+| bucket_name | The name of the bucket where logs are sent |
+| elb_ip | The ELB DNS Name for the Bastion Host instances |
+| bastion_host_security_group_id | The security group ID of the Bastion Host |
+| private_instances_security_group | The security group ID of the the private instances that allow Bastion SSH ingress |
 
 Known issues
 ------------

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,9 @@ data "template_file" "user_data" {
   template = file("${path.module}/user_data.sh")
 
   vars = {
-    aws_region  = var.region
-    bucket_name = var.bucket_name
+    aws_region              = var.region
+    bucket_name             = var.bucket_name
+    extra_user_data_content = var.extra_user_data_content
   }
 }
 

--- a/user_data.sh
+++ b/user_data.sh
@@ -171,3 +171,10 @@ cat > ~/mycron << EOF
 EOF
 crontab ~/mycron
 rm ~/mycron
+
+
+#########################################
+## Add Custom extra_user_data_content ##
+#######################################
+
+${extra_user_data_content}

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,8 @@ variable "private_ssh_port" {
   default     = 22
 }
 
+variable "extra_user_data_content" {
+  description = "Additional scripting to pass to the bastion host. For example, this can include installing postgresql for the `psql` command."
+  type = string
+  default = ""
+}


### PR DESCRIPTION
This accomplishes two updates: 

1. Adds the `extra_user_data_content` variable to support additional scripting at the end of the `user_data.sh` script. I needed this to support adding Postgres so I can use `psql` to my RDS instances from my Bastion box. Here is an example: 

```
module "bastion" {
  source                            = "git::https://github.com/Gowiem/terraform-aws-bastion.git?ref=a0d38256ae93dc06132d18049233a4efa18efe4d"
  # ... 

  # Install Postgres to allow Bastion box to execute `psql`
  extra_user_data_content           = <<EOT
sudo amazon-linux-extras install postgresql10 vim epel -y
sudo yum install -y postgresql-server postgresql-devel
EOT

}
```

2. Adds documentation to the README for missing output variables. I went looking at add an output variable for the bastion host SG and there it was. Added these so others know that they are around. 