### PR TITLE
Adds ability to pass Bastion AMI + Adds `allow_ssh_commands` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ module "bastion" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | auto_scaling_group_subnets | List of subnet were the Auto Scalling Group will deploy the instances | list | - | yes |
+| allow_ssh_commands | Allows the SSH user to execute one-off commands. Pass 'True' to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion. | string | "" | no |
 | bastion_amis |  | map | `<map>` | no |
 | bastion_host_key_pair | Select the key pair to use to launch the bastion host | string | - | yes |
 | bastion_instance_count | Count of bastion instance created on VPC | string | `1` | no |

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ module "bastion" {
 |------|-------------|:----:|:-----:|:-----:|
 | auto_scaling_group_subnets | List of subnet were the Auto Scalling Group will deploy the instances | list | - | yes |
 | allow_ssh_commands | Allows the SSH user to execute one-off commands. Pass 'True' to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion. | string | "" | no |
-| bastion_amis |  | map | `<map>` | no |
 | bastion_host_key_pair | Select the key pair to use to launch the bastion host | string | - | yes |
 | bastion_instance_count | Count of bastion instance created on VPC | string | `1` | no |
+| bastion_launch_configuration_name | Bastion Launch configuration Name, will also be used for the ASG | string | `lc` | no |
+| bastion_ami | The AMI that the Bastion Host will use. If not supplied, the latest Amazon2 AMI will be used. | string | `` | no |
 | bastion_record_name | DNS record name to use for the bastion | string | `` | no |
 | bucket_name | Bucket name were the bastion will store the logs | string | - | yes |
 | bucket_force_destroy | On destroy, bucket and all objects should be destroyed when using true | string | false | no |

--- a/main.tf
+++ b/main.tf
@@ -220,7 +220,7 @@ resource "aws_iam_instance_profile" "bastion_host_profile" {
 
 resource "aws_launch_configuration" "bastion_launch_configuration" {
   name_prefix                 = var.bastion_launch_configuration_name
-  image_id                    = data.aws_ami.amazon-linux-2.id
+  image_id                    = var.bastion_ami != "" ? var.bastion_ami : data.aws_ami.amazon-linux-2.id
   instance_type               = "t2.nano"
   associate_public_ip_address = var.associate_public_ip_address
   enable_monitoring           = true

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ data "template_file" "user_data" {
     aws_region              = var.region
     bucket_name             = var.bucket_name
     extra_user_data_content = var.extra_user_data_content
+    allow_ssh_commands      = var.allow_ssh_commands
   }
 }
 

--- a/user_data.sh
+++ b/user_data.sh
@@ -45,12 +45,16 @@ if [[ -z $SSH_ORIGINAL_COMMAND ]]; then
 
 else
 
-  # The "script" program could be circumvented with some commands (e.g. bash, nc).
-  # Therefore, I intentionally prevent users from supplying commands.
+  # If the module consumer wants to allow remote commands (for ansible or other) then allow that command through.
+  if [ "${allow_ssh_commands}" == "True" ]; then
+    exec /bin/bash -c "$SSH_ORIGINAL_COMMAND"
+  else
+    # The "script" program could be circumvented with some commands (e.g. bash, nc).
+    # Therefore, I intentionally prevent users from supplying commands.
 
-  echo "This bastion supports interactive sessions only. Do not supply a command"
-  exit 1
-
+    echo "This bastion supports interactive sessions only. Do not supply a command"
+    exit 1
+  end
 fi
 
 EOF

--- a/user_data.sh
+++ b/user_data.sh
@@ -54,7 +54,7 @@ else
 
     echo "This bastion supports interactive sessions only. Do not supply a command"
     exit 1
-  end
+  fi
 fi
 
 EOF

--- a/variables.tf
+++ b/variables.tf
@@ -114,3 +114,9 @@ variable "extra_user_data_content" {
   type = string
   default = ""
 }
+
+variable "allow_ssh_commands" {
+  description = "Allows the SSH user to execute one-off commands. Pass 'True' to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion."
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,8 +53,15 @@ variable "bastion_record_name" {
 }
 
 variable "bastion_launch_configuration_name" {
+  type        = string
   description = "Bastion Launch configuration Name, will also be used for the ASG"
   default     = "lc"
+}
+
+variable "bastion_ami" {
+  type        = string
+  description = "The AMI that the Bastion Host will use."
+  default     = ""
 }
 
 variable "elb_subnets" {


### PR DESCRIPTION
## Info

This PR does the following: 

1. Adds the the `bastion_ami` variable for BYOAMI 
2. Adds the `allow_ssh_commands` variable, which is useful when using the Bastion host as an entry point for Ansible.  