### PR TITLE
hotfix: restore instance profile permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,15 @@ data "aws_iam_policy_document" "bastion_host_policy_document" {
 
 }
 
+resource "aws_iam_policy" "bastion_host_policy" {
+  name   = "BastionHost"
+  policy = data.aws_iam_policy_document.bastion_host_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "bastion_host" {
+  policy_arn = aws_iam_policy.bastion_host_policy.arn
+  role       = aws_iam_role.bastion_host_role.name
+}
 
 resource "aws_route53_record" "bastion_record_name" {
   name    = var.bastion_record_name


### PR DESCRIPTION
In a previous commit (#65),
   the iam role policy was converted into a nicer looking data
   object, but the requisite additional resources were not created.

Without this, the bastion cannot create new user accounts and cannot log access.