### PR TITLE
fixing missing kms key id on s3 bucket object

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "aws_s3_bucket_object" "bucket_public_keys_readme" {
   bucket  = aws_s3_bucket.bucket.id
   key     = "public-keys/README.txt"
   content = "Drop here the ssh public keys of the instances you want to control"
+  kms_key_id = aws_kms_key.key.id
 }
 
 resource "aws_security_group" "bastion_host_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "aws_s3_bucket_object" "bucket_public_keys_readme" {
   bucket  = aws_s3_bucket.bucket.id
   key     = "public-keys/README.txt"
   content = "Drop here the ssh public keys of the instances you want to control"
-  kms_key_id = aws_kms_key.key.id
+  kms_key_id = aws_kms_key.key.arn
 }
 
 resource "aws_security_group" "bastion_host_security_group" {


### PR DESCRIPTION
This fixes an issue with idempotency when subsequent runs detect a kms encryption key on the bucket object yet there is no kms key defined for the object in the module. 