### PR TITLE
Fix bastion launch template name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "bastion_record_name" {
 
 variable "bastion_launch_template_name" {
   description = "Bastion Launch template Name, will also be used for the ASG"
-  default     = "lt"
+  default     = "bastion-lt"
 }
 
 variable "bastion_ami" {


### PR DESCRIPTION
Without this, runs fail with

```
Error: "name_prefix" cannot be less than 3 characters

  on .terraform/modules/rds_bastion/terraform-aws-bastion-1.2.1/main.tf line 240, in resource "aws_launch_template" "bastion_launch_template":
 240: resource "aws_launch_template" "bastion_launch_template" {
```