### PR TITLE
add var for iam policy name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module "bastion" {
   "bastion_host_key_pair" = "my_key_pair"
   "hosted_zone_id" = "my.hosted.zone.name."
   "bastion_record_name" = "bastion.my.hosted.zone.name."
+  "bastion_iam_policy_name" = "myBastionHostPolicy"
   "elb_subnets" = [
     "subnet-id1a",
     "subnet-id1b"
@@ -65,6 +66,7 @@ module "bastion" {
 | bastion_launch_configuration_name | Bastion Launch configuration Name, will also be used for the ASG | string | `lc` | no |
 | bastion_ami | The AMI that the Bastion Host will use. If not supplied, the latest Amazon2 AMI will be used. | string | `` | no |
 | bastion_record_name | DNS record name to use for the bastion | string | `` | no |
+| bastion_host_policy_name | IAM Policy Name to create for the bastion ibnstance role | string | `BastionHost` | no |
 | bucket_name | Bucket name were the bastion will store the logs | string | - | yes |
 | bucket_force_destroy | On destroy, bucket and all objects should be destroyed when using true | string | false | no |
 | bucket_versioning | Enable bucket versioning or not | string | true | no |

--- a/main.tf
+++ b/main.tf
@@ -184,7 +184,7 @@ data "aws_iam_policy_document" "bastion_host_policy_document" {
 }
 
 resource "aws_iam_policy" "bastion_host_policy" {
-  name   = "BastionHost"
+  name   = var.bastion_iam_policy_name
   policy = data.aws_iam_policy_document.bastion_host_policy_document.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -126,3 +126,8 @@ variable "allow_ssh_commands" {
   type        = string
   default     = ""
 }
+
+variable "bastion_iam_policy_name" {
+  description = "IAM policy name to create for granting the instance role access to the bucket"
+  default     = "BastionHost"
+}


### PR DESCRIPTION
Adding a var for the iam policy name so that you can run multiple instances of the module in the same aws account.