### PR TITLE
Add the ability to provide your own security group. + support for additional security groups.

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,6 +2,7 @@ locals {
   tags_asg_format = null_resource.tags_as_list_of_maps.*.triggers
 
   name_prefix = var.bastion_launch_template_name
+  security_group = join("", flatten([aws_security_group.bastion_host_security_group[*].id, var.bastion_security_group_id]))
 }
 
 resource "null_resource" "tags_as_list_of_maps" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "bastion_host_security_group" {
-  value = aws_security_group.bastion_host_security_group.id
+  value = aws_security_group.bastion_host_security_group[*].id
 }
 
 output "bucket_kms_key_alias" {

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,17 @@ variable "bastion_launch_template_name" {
   default     = "bastion-lt"
 }
 
+variable "bastion_security_group_id" {
+  description = "Custom security group to use"
+  default = ""
+}
+
+variable "bastion_additional_security_groups" {
+ description = "List of additional security groups to attach to the launch template"
+ type = list(string)
+ default = []
+}
+
 variable "bastion_ami" {
   type        = string
   description = "The AMI that the Bastion Host will use."


### PR DESCRIPTION
### The need for this change.
We have extra requirements to provide additional ingress/egress rules to our bastion. In order to support this, I have added the ability to provide your own main security group, and further integration to add additional groups onto your launch template used by the ASG.

### Use case

These variables can be passed as optional variables.
bastion_security_group_id: defaults to "" and instructs to use defaults.
bastion_additional_security_groups: defaults to empty list. This expects a list of additional security groups.

```hcl
  bastion_security_group_id                 = data.aws_security_group.vpn.id
  bastion_additional_security_groups        = [data.aws_security_group.extras.id]
```
The use case above shows how I used my own resources to pass my own security groups.

### Testing
I've tested locally for our own production use. But if people like this approach and I get the blessing from the author. Then I can look into adding some tests for it.