### PR TITLE
Updated source name in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage
 
 ```hcl
 module "bastion" {
-  "source" = "terraform-aws-modules/bastion/aws"
+  "source" = "Guimove/bastion/aws"
   "bucket_name" = "my_famous_bucket_name"
   "region" = "eu-west-1"
   "vpc_id" = "my_vpc_id"

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_kms_alias" "alias" {
 
 resource "aws_s3_bucket" "bucket" {
   bucket = var.bucket_name
-  acl    = "bucket-owner-full-control"
+  acl    = "private"
 
   server_side_encryption_configuration {
     rule {


### PR DESCRIPTION
When trying to use this I was getting the following error.

```
Module "bastion" (from bastion.tf:18) cannot be found in the module registry
at registry.terraform.io.
```

This was fixed by using the source name provided in this PR.

Additionally: I was getting this error when running for the first time.

```

Error: expected acl to be one of [private public-read public-read-write authenticated-read aws-exec-read log-delivery-write], got bucket-owner-full-control

  on .terraform/modules/bastion/main.tf line 24, in resource "aws_s3_bucket" "bucket":
  24:   acl    = "bucket-owner-full-control"
```

So I changed the acl to be `private`