### PR TITLE
Add autoscaling group name to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ module "bastion" {
 | bucket\_name | The name of the bucket where logs are sent |
 | elb\_ip | The ELB DNS Name for the Bastion Host instances |
 | private\_instances\_security\_group | The security group ID of the the private instances that allow Bastion SSH ingress |
+| bastion\_auto\_scaling\_group | The autoscaling group name |
 
 Known issues
 ------------

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,6 @@ output "private_instances_security_group" {
   value = aws_security_group.private_instances_security_group.id
 }
 
+output "bastion_auto_scaling_group_name" {
+  value = aws_autoscaling_group.bastion_auto_scaling_group.name
+}


### PR DESCRIPTION
This could be handy for setting up alarms on autoscaling group metrics which might be required for security or other reasons.