### PR TITLE
Add bastion_iam_role_name to variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ module "bastion" {
 | bastion\_ami | The AMI that the Bastion Host will use. | `string` | `""` | no |
 | bastion\_host\_key\_pair | Select the key pair to use to launch the bastion host | `any` | n/a | yes |
 | bastion\_iam\_policy\_name | IAM policy name to create for granting the instance role access to the bucket | `string` | `"BastionHost"` | no |
+| bastion\_iam\_role\_name | IAM role name to create | `string` | `null` | no |
 | bastion\_instance\_count | Number of instances to create | `number` | `1` | no |
 | bastion\_launch\_template\_name | Bastion Launch template Name, will also be used for the ASG | `string` | `"bastion-lt"` | no |
 | bastion\_record\_name | DNS record name to use for the bastion | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,7 @@ data "aws_iam_policy_document" "assume_policy_document" {
 }
 
 resource "aws_iam_role" "bastion_host_role" {
+  name                 = var.bastion_iam_role_name
   path                 = "/"
   assume_role_policy   = data.aws_iam_policy_document.assume_policy_document.json
   permissions_boundary = var.bastion_iam_permissions_boundary

--- a/variables.tf
+++ b/variables.tf
@@ -138,6 +138,12 @@ variable "allow_ssh_commands" {
   default     = false
 }
 
+variable "bastion_iam_role_name" {
+  description = "IAM role name to create"
+  type        = string
+  default     = null
+}
+
 variable "bastion_iam_policy_name" {
   description = "IAM policy name to create for granting the instance role access to the bucket"
   default     = "BastionHost"


### PR DESCRIPTION
This PR adds optional `bastion_iam_role_name` variable that is used as a name of the IAM role of the instance profile. Beforehand the name wasn't specified and Terraform was generating names that looked like `terraform-202107....`.

This could be useful for extending policies of the EC2 instance profile, for instance, for adding `AmazonSSMManagedInstanceCore` to be able to manage the instance using Systems Manager.