### PR TITLE
Add IPv6 ingress support to bastion host

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ module "bastion" {
 | extra\_user\_data\_content | Additional scripting to pass to the bastion host. For example, this can include installing postgresql for the `psql` command. | `string` | `""` | no |
 | hosted\_zone\_id | Name of the hosted zone were we'll register the bastion DNS name | `string` | `""` | no |
 | instance\_type | Instance size of the bastion | `string` | `"t3.nano"` | no |
+| ipv6_cidrs | List of IPv6 CIDRs than can access to the bastion. Default : ::/0 | `list(string)` | <pre>[<br>  "::/0"<br>]</pre> | no |
 | is\_lb\_private | If TRUE the load balancer scheme will be "internal" else "internet-facing" | `any` | n/a | yes |
 | kms\_enable\_key\_rotation | Enable KMS key rotation | `bool` | `false` | no |
 | log\_auto\_clean | Enable or not the lifecycle | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,7 @@ resource "aws_security_group_rule" "ingress_bastion" {
   to_port     = var.public_ssh_port
   protocol    = "TCP"
   cidr_blocks = concat(data.aws_subnet.subnets.*.cidr_block, var.cidrs)
+  ipv6_ipv6_cidr_blocks = concat(data.aws_subnet.subnets.*.ipv6_ipv6_cidr_blocks, var.ipv6_cidrs)
 
   security_group_id = local.security_group
 }

--- a/main.tf
+++ b/main.tf
@@ -78,14 +78,14 @@ resource "aws_security_group" "bastion_host_security_group" {
 }
 
 resource "aws_security_group_rule" "ingress_bastion" {
-  count       = var.bastion_security_group_id == "" ? 1 : 0
-  description = "Incoming traffic to bastion"
-  type        = "ingress"
-  from_port   = var.public_ssh_port
-  to_port     = var.public_ssh_port
-  protocol    = "TCP"
-  cidr_blocks = concat(data.aws_subnet.subnets.*.cidr_block, var.cidrs)
-  ipv6_ipv6_cidr_blocks = concat(data.aws_subnet.subnets.*.ipv6_ipv6_cidr_blocks, var.ipv6_cidrs)
+  count            = var.bastion_security_group_id == "" ? 1 : 0
+  description      = "Incoming traffic to bastion"
+  type             = "ingress"
+  from_port        = var.public_ssh_port
+  to_port          = var.public_ssh_port
+  protocol         = "TCP"
+  cidr_blocks      = concat(data.aws_subnet.subnets.*.cidr_block, var.cidrs)
+  ipv6_cidr_blocks = concat(data.aws_subnet.subnets.*.ipv6_cidr_blocks, var.ipv6_cidrs)
 
   security_group_id = local.security_group
 }

--- a/variables.tf
+++ b/variables.tf
@@ -182,3 +182,12 @@ variable "kms_enable_key_rotation" {
   type        = bool
   default     = false
 }
+
+variable "ipv6_cidrs" {
+  description = "List of IPv6 CIDRs than can access to the bastion. Default : ::/0"
+  type        = list(string)
+
+  default = [
+    "::/0",
+  ]
+}


### PR DESCRIPTION
Adds IPv6 ingress support to bastion hosts.  My use case is to allow Github Actions Runners access to the bastion host.  Their API outputs both IPv4 and IPv6 addressing that I'd like to input into this module.