### PR TITLE
updating main.tf and adding to locals.tf to resolve ipv6 error 

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,10 @@
 locals {
   name_prefix    = var.bastion_launch_template_name
   security_group = join("", flatten([aws_security_group.bastion_host_security_group[*].id, var.bastion_security_group_id]))
+
+  // the compact() function checks for null values and gets rid of them 
+  // the length is a check to ensure we dont have an empty array, as an empty array would throw an error for the cidr_block argument 
+  ipv4_cidr_block = length(compact(data.aws_subnet.subnets[*].cidr_block)) == 0 ? null : concat(data.aws_subnet.subnets[*].cidr_block, var.cidrs)
+  ipv6_cidr_block = length(compact(data.aws_subnet.subnets[*].ipv6_cidr_block)) == 0 ? null : concat(data.aws_subnet.subnets[*].ipv6_cidr_block, var.ipv6_cidrs)
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -4,6 +4,7 @@ locals {
 
   // the compact() function checks for null values and gets rid of them 
   // the length is a check to ensure we dont have an empty array, as an empty array would throw an error for the cidr_block argument 
+  ipv4_cidr_block = length(compact(data.aws_subnet.subnets[*].cidr_block)) == 0 ? null : concat(data.aws_subnet.subnets[*].cidr_block, var.cidrs)
   ipv6_cidr_block = length(compact(data.aws_subnet.subnets[*].ipv6_cidr_block)) == 0 ? null : concat(data.aws_subnet.subnets[*].ipv6_cidr_block, var.ipv6_cidrs)
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,6 @@ locals {
 
   // the compact() function checks for null values and gets rid of them 
   // the length is a check to ensure we dont have an empty array, as an empty array would throw an error for the cidr_block argument 
-  ipv4_cidr_block = length(compact(data.aws_subnet.subnets[*].cidr_block)) == 0 ? null : concat(data.aws_subnet.subnets[*].cidr_block, var.cidrs)
   ipv6_cidr_block = length(compact(data.aws_subnet.subnets[*].ipv6_cidr_block)) == 0 ? null : concat(data.aws_subnet.subnets[*].ipv6_cidr_block, var.ipv6_cidrs)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "ingress_bastion" {
   from_port        = var.public_ssh_port
   to_port          = var.public_ssh_port
   protocol         = "TCP"
-  cidr_blocks      = local.ipv4_cidr_block
+  cidr_blocks      = concat(data.aws_subnet.subnets[*].cidr_block, var.cidrs)
   ipv6_cidr_blocks = local.ipv6_cidr_block
 
   security_group_id = local.security_group

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "ingress_bastion" {
   from_port        = var.public_ssh_port
   to_port          = var.public_ssh_port
   protocol         = "TCP"
-  cidr_blocks      = concat(data.aws_subnet.subnets[*].cidr_block, var.cidrs)
+  cidr_blocks      = local.ipv4_cidr_block
   ipv6_cidr_blocks = local.ipv6_cidr_block
 
   security_group_id = local.security_group

--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,8 @@ resource "aws_security_group_rule" "ingress_bastion" {
   from_port        = var.public_ssh_port
   to_port          = var.public_ssh_port
   protocol         = "TCP"
-  cidr_blocks      = concat(data.aws_subnet.subnets.*.cidr_block, var.cidrs)
-  ipv6_cidr_blocks = concat(data.aws_subnet.subnets.*.ipv6_cidr_block, var.ipv6_cidrs)
+  cidr_blocks      = local.ipv4_cidr_block
+  ipv6_cidr_blocks = local.ipv6_cidr_block
 
   security_group_id = local.security_group
 }


### PR DESCRIPTION
Description
---
Commit https://github.com/Guimove/terraform-aws-bastion/commit/df6830573f2832e9a50e419c8284c133fda19463 added the `ipv6_cidr_blocks` argument to the `aws_security_group_rule`  ingress resource  on line 39 of main.tf https://github.com/Guimove/terraform-aws-bastion/blob/e6332cdd7daf1b7fa004e248b58b07c7727660f7/main.tf#L39

This addition creates an error if the subnets do not have ipv6 addresses resulting in similar to the following error:
```hcl
Error: "" is not a valid CIDR block: invalid CIDR address: 
│ 
│   with module.test_bastion.module.test_bastion.aws_security_group_rule.ingress_bastion[0],
│   on .terraform/modules/test_bastion.test_bastion/main.tf line 39, in resource "aws_security_group_rule" "ingress_bastion":
│   39:   ipv6_cidr_blocks = concat(data.aws_subnet.subnets.*.ipv6_cidr_block, var.ipv6_cidrs)
```

Changes Made
---
- added the `ipv6_cidr_block` parameter to the locals.tf file so that a list of empty strings will set the  `ipv6_cidr_blocks`  argument to null. The null value tells terraform to omit the optional argument.  
- updated the splat expression to latest syntax