### PR TITLE
Auto instance refresh

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -291,6 +291,10 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
     propagate_at_launch = true
   }
 
+  instance_refresh {
+    strategy = "Rolling"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -255,7 +255,7 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
   name_prefix = "ASG-${local.name_prefix}"
   launch_template {
     id      = aws_launch_template.bastion_launch_template.id
-    version = "$Latest"
+    version = aws_launch_template.bastion_launch_template.latest_version
   }
   max_size         = var.bastion_instance_count
   min_size         = var.bastion_instance_count


### PR DESCRIPTION
This change will enable instance refreshes of bastions when bastion configuration changes, such as when rotating the ec2 keypair.

From https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group:

> NOTE:
> A refresh will not start when `version = "$Latest"` is configured in the `launch_template` block. To trigger the instance refresh when a launch template is changed, configure `version` to use the `latest_version` attribute of the `aws_launch_template` resource.