### PR TITLE
add bucket, ln, tg outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -11,11 +11,23 @@ output "bucket_kms_key_arn" {
 }
 
 output "bucket_name" {
-  value = aws_s3_bucket.bucket.bucket
+  value = aws_s3_bucket.bucket.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.bucket.arn
 }
 
 output "elb_ip" {
   value = aws_lb.bastion_lb.dns_name
+}
+
+output "elb_arn" {
+  value = aws_lb.bastion_lb.arn
+}
+
+output "target_group_arn" {
+  value = aws_lb_target_group.bastion_lb_target_group.arn
 }
 
 output "private_instances_security_group" {


### PR DESCRIPTION
Three new output values have been added.

1. The ARN of the S3 Bucket holding the SSH public keys.
2. The ARN of the _bastion_lb_.
3. The ARN of the target group.

These output values are necessary to create new LB Listener Rules and a new IAM Resource Policy to control access to the bucket. I would like to add a listener rule that includes Source IP addresses, and I would like to limit who can manipulate the bucket to a particular role. With these new outputs, I can create the desired resources in Terraform alongside the creation of the instance of this module.

The _bucket_name_ internal attribute has been changed from _name_ to _id_ to conform to the Terraform attributes list.