### PR TITLE
Adds output load balancer id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,7 @@ output "private_instances_security_group" {
 output "bastion_auto_scaling_group_name" {
   value = aws_autoscaling_group.bastion_auto_scaling_group.name
 }
+
+output "bastion_elb_id" {
+  value = aws_lb.bastion_lb.id
+}


### PR DESCRIPTION
The elb id would be used alongside other resources. For my specific use case, I need a reverse ssh tunnel that needs to connect through the elb and I need to add listeners and target groups