### PR TITLE
Adds bastion host iam role id to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ No modules.
 |------|-------------|
 | <a name="output_bastion_auto_scaling_group_name"></a> [bastion\_auto\_scaling\_group\_name](#output\_bastion\_auto\_scaling\_group\_name) | The name of the Auto Scaling Group for bastion hosts |
 | <a name="output_bastion_elb_id"></a> [bastion\_elb\_id](#output\_bastion\_elb\_id) | The ID of the ELB for bastion hosts |
+| <a name="output_bastion_host_iam_role_id"></a> [bastion\_host\_iam\_role\_id](#output\_bastion\_host\_iam\_role\_id) | The ID of the bastion host IAM role |
 | <a name="output_bastion_host_security_group"></a> [bastion\_host\_security\_group](#output\_bastion\_host\_security\_group) | The ID of the bastion host security group |
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | The ARN of the S3 bucket |
 | <a name="output_bucket_kms_key_alias"></a> [bucket\_kms\_key\_alias](#output\_bucket\_kms\_key\_alias) | The name of the KMS key alias for the bucket |

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "bastion_elb_id" {
   value       = var.create_elb ? try(aws_lb.bastion_lb[0].id, null) : null
 }
 
+output "bastion_host_iam_role_id" {
+  description = "The ID of the bastion host iam role"
+  value       = aws_iam_role.bastion_host_role.id
+}
+
 output "bastion_host_security_group" {
   description = "The ID of the bastion host security group"
   value       = aws_security_group.bastion_host_security_group[*].id


### PR DESCRIPTION
Adds an output for the bastion host iam role id. I needed this so I could attach additional `aws_iam_role_policy_attachment`s outside of the module.