### PR TITLE
Fix: Issue 164 - SSH rule creation for bastion host without ELB.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_security_group" "bastion_host_security_group" {
 }
 
 resource "aws_security_group_rule" "ingress_bastion" {
-  count            = var.bastion_security_group_id == "" && var.create_elb ? 1 : 0
+  count            = var.bastion_security_group_id == "" || var.create_elb ? 1 : 0
   description      = "Incoming traffic to bastion"
   type             = "ingress"
   from_port        = var.public_ssh_port


### PR DESCRIPTION
### SSH rule creation for bastion host without ELB.

This pull request addresses the issue where SSH access wasn't properly configured for bastion hosts when ELB (Elastic Load Balancer) creation was disabled. The problem occurred due to the conditional logic in the count attribute, which excluded SSH rule creation when create_elb was set to false. 

This was a critical issue as it prevented secure access to the bastion host in scenarios where ELB wasn't used.

### Changes Made.

Modified the count attribute in the Terraform configuration for bastion host security groups to allow SSH rule creation when one of the following conditions is met:

- The bastion_security_group_id is an empty string.

- The create_elb is set to false.

Related Issues:

Closes #164